### PR TITLE
Ensure Car.drive handles invalid distance and improves output

### DIFF
--- a/Learning_Python/Helsinki/part_9/Car.py
+++ b/Learning_Python/Helsinki/part_9/Car.py
@@ -39,6 +39,9 @@ class Car:
 
     
     def drive(self, km: int):
+        if km < 0:
+            raise ValueError("Distance to drive must be non-negative")
+
         if self.__petrol >= km:
            self.__petrol -= km
            self.__odometer += km
@@ -48,7 +51,7 @@ class Car:
            print("Insufficient fuel to continue journey.")
     
     def __str__(self) -> str:
-        return (f"Odometer: {self.__odometer} km, Petrol: y litres : {self.__petrol}")
+        return (f"Odometer: {self.__odometer} km, Petrol: {self.__petrol} litres")
     
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Validate that `Car.drive` rejects negative distance values
- Correct string representation of `Car` to show petrol level correctly

## Testing
- `python Learning_Python/Helsinki/part_9/Car.py`
- `python - <<'PY'
from Learning_Python.Helsinki.part_9.Car import Car
car=Car()
try:
    car.drive(-5)
except ValueError as e:
    print('error:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a299c75f248323b4f33e13ed503375